### PR TITLE
Implement file-rolling mechanism

### DIFF
--- a/src/datasources/ascii/asciiconfig.ui
+++ b/src/datasources/ascii/asciiconfig.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>739</width>
-    <height>524</height>
+    <width>917</width>
+    <height>579</height>
    </rect>
   </property>
   <property name="maximumSize">
@@ -466,11 +466,8 @@ own constant width</string>
        <property name="title">
         <string>General Options</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="bottomMargin">
-         <number>3</number>
-        </property>
-        <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QCheckBox" name="_limitFileBuffer">
@@ -503,14 +500,31 @@ own constant width</string>
           </item>
          </layout>
         </item>
-        <item>
-         <widget class="QCheckBox" name="_useThreads">
-          <property name="text">
-           <string>Use threads</string>
-          </property>
-         </widget>
+        <item row="1" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_14">
+          <item>
+           <widget class="QCheckBox" name="_useThreads">
+            <property name="text">
+             <string>Use threads</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="_fileRolling">
+            <property name="toolTip">
+             <string>Reload when file is overwritten</string>
+            </property>
+            <property name="whatsThis">
+             <string>Reload when file is overwritten</string>
+            </property>
+            <property name="text">
+             <string>Roll file</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
-        <item>
+        <item row="2" column="0">
          <layout class="QHBoxLayout" name="horizontalLayout_16">
           <item>
            <widget class="QLabel" name="textLabel1_2">
@@ -533,14 +547,14 @@ own constant width</string>
           </item>
          </layout>
         </item>
-        <item>
+        <item row="3" column="0">
          <widget class="QLabel" name="label_4">
           <property name="text">
            <string>Interpret empty value as:</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="4" column="0">
          <layout class="QHBoxLayout" name="horizontalLayout_6">
           <item>
            <spacer name="horizontalSpacer_6">
@@ -587,7 +601,7 @@ own constant width</string>
           </item>
          </layout>
         </item>
-        <item>
+        <item row="5" column="0">
          <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -867,7 +881,7 @@ own constant width</string>
                </property>
                <property name="dateTime">
                 <datetime>
-                 <hour>8</hour>
+                 <hour>7</hour>
                  <minute>0</minute>
                  <second>0</second>
                  <year>2000</year>
@@ -884,7 +898,7 @@ own constant width</string>
                </property>
                <property name="time">
                 <time>
-                 <hour>8</hour>
+                 <hour>7</hour>
                  <minute>0</minute>
                  <second>0</second>
                 </time>

--- a/src/datasources/ascii/asciiconfigwidget.cpp
+++ b/src/datasources/ascii/asciiconfigwidget.cpp
@@ -176,6 +176,7 @@ AsciiSourceConfig AsciiConfigWidgetInternal::config()
   config._limitFileBuffer = _limitFileBuffer->isChecked();
   config._limitFileBufferSize = (qint64)_limitFileBufferSize->value() * 1024 * 1024;
   config._useThreads =_useThreads->isChecked();
+  config._fileRolling =_fileRolling->isChecked();
   config._timeAsciiFormatString = _timeAsciiFormatString->text();
   config._dataRate = _dataRate->value();
   config._offsetDateTime = _offsetDateTime->isChecked();
@@ -238,6 +239,7 @@ void AsciiConfigWidgetInternal::setConfig(const AsciiSourceConfig& config)
   _limitFileBufferSize->setValue(config._limitFileBufferSize / 1024 / 1024);
 
   _useThreads->setChecked(config._useThreads);
+  _fileRolling->setChecked(config._fileRolling);
   _timeAsciiFormatString->setText(config._timeAsciiFormatString);
   _dataRate->setValue(config._dataRate.value());
   _offsetDateTime->setChecked(config._offsetDateTime.value());

--- a/src/datasources/ascii/asciisource.cpp
+++ b/src/datasources/ascii/asciisource.cpp
@@ -14,7 +14,6 @@
 #include "asciidatainterfaces.h"
 
 #include "curve.h"
-#include "colorsequence.h"
 #include "objectstore.h"
 
 #include "math_kst.h"
@@ -29,14 +28,12 @@
 #include <QThread>
 #include <QtConcurrentRun>
 #include <QFutureSynchronizer>
-#include <QLabel>
 #include <QApplication>
 #include <QVBoxLayout>
-#include <QProgressBar>
 
 
-#include <ctype.h>
 #include <stdlib.h>
+#include <updatemanager.h>
 
 
 using namespace Kst;
@@ -225,6 +222,18 @@ Kst::Object::UpdateType AsciiSource::internalDataSourceUpdate(bool read_complete
   bool force_update = true;
   if (_fileSize == file.size()) {
     force_update = false;
+  }
+
+  //Check if file has been overwritten, and reload in case file rolling option is selected
+  if(_fileSize < _lastFileSize) {
+    if(this->_config._fileRolling) {
+      emit UpdateManager::self()->askToReload();
+      //Do nothing right now. Let the main application to handle reload.
+      return NoChange;
+    }
+    else {
+      Debug::self()->notice("File size is less than previous (overwritten?). Consider to enable file rolling");
+    }
   }
 
   _fileCreationTime_t = QFileInfo(file).created().toTime_t();

--- a/src/datasources/ascii/asciisourceconfig.cpp
+++ b/src/datasources/ascii/asciisourceconfig.cpp
@@ -60,6 +60,8 @@ const char AsciiSourceConfig::Key_limitFileBufferSize[] = "Size of limited file 
 const char AsciiSourceConfig::Tag_limitFileBufferSize[] = "limitFileBufferSize";
 const char AsciiSourceConfig::Key_useThreads[] = "Use threads when parsing Ascii data";
 const char AsciiSourceConfig::Tag_useThreads[] = "useThreads";
+const char AsciiSourceConfig::Key_fileRolling[] = "Reload when file size is less than previous";
+const char AsciiSourceConfig::Tag_fileRolling[] = "fileRolling";
 const char AsciiSourceConfig::Key_dataRate[] = "Data Rate for index";
 const char AsciiSourceConfig::Tag_dataRate[] = "dataRate";
 const char AsciiSourceConfig::Key_offsetDateTime[] = "use an explicit date/time offset";
@@ -96,6 +98,7 @@ AsciiSourceConfig::AsciiSourceConfig() :
   _limitFileBuffer(false),
   _limitFileBufferSize(100),
   _useThreads(false),
+  _fileRolling(false),
   _dataRate(1.0),
   _offsetDateTime(false),
   _offsetFileDate(false),
@@ -127,6 +130,7 @@ void AsciiSourceConfig::save(QSettings& cfg) const {
   _limitFileBuffer >> cfg;
   _limitFileBufferSize >> cfg;
   _useThreads >> cfg;
+  _fileRolling >> cfg;
   _timeAsciiFormatString >> cfg;
   _dataRate >> cfg;
   _offsetDateTime >> cfg;
@@ -175,6 +179,7 @@ void AsciiSourceConfig::read(QSettings& cfg) {
   _limitFileBuffer << cfg;
   _limitFileBufferSize << cfg;
   _useThreads << cfg;
+  _fileRolling << cfg;
   _timeAsciiFormatString << cfg;
   _dataRate << cfg;
   _offsetDateTime << cfg;
@@ -226,6 +231,7 @@ void AsciiSourceConfig::save(QXmlStreamWriter& s) {
   _limitFileBuffer >> s;
   _limitFileBufferSize >> s;
   _useThreads >> s;
+  _fileRolling >> s;
   _timeAsciiFormatString >> s;
   _dataRate >> s;
   _offsetDateTime >> s;
@@ -257,6 +263,7 @@ void AsciiSourceConfig::parseProperties(QXmlStreamAttributes& attributes) {
   _limitFileBuffer << attributes;
   _limitFileBufferSize << attributes;
   _useThreads << attributes;
+  _fileRolling << attributes;
   _timeAsciiFormatString << attributes;
   _dataRate << attributes;
   _offsetDateTime << attributes;
@@ -292,6 +299,7 @@ void AsciiSourceConfig::load(const QDomElement& e) {
         _limitFileBuffer << elem;
         _limitFileBufferSize << elem;
         _useThreads << elem;
+        _fileRolling << elem;
         _timeAsciiFormatString << elem;
         _dataRate << elem;
         _offsetDateTime << elem;
@@ -327,6 +335,7 @@ bool AsciiSourceConfig::operator==(const AsciiSourceConfig& rhs) const
       _limitFileBuffer == rhs._limitFileBuffer &&
       _limitFileBufferSize == rhs._limitFileBufferSize &&
       _useThreads == rhs._useThreads &&
+      _fileRolling == rhs._fileRolling &&
       _timeAsciiFormatString == rhs._timeAsciiFormatString &&
       _dataRate == rhs._dataRate &&
       _offsetDateTime == rhs._offsetDateTime &&

--- a/src/datasources/ascii/asciisourceconfig.h
+++ b/src/datasources/ascii/asciisourceconfig.h
@@ -58,6 +58,8 @@ class AsciiSourceConfig {
     static const char Tag_limitFileBufferSize[];
     static const char Key_useThreads[];
     static const char Tag_useThreads[];
+    static const char Key_fileRolling[];
+    static const char Tag_fileRolling[];
     static const char Key_dataRate[];
     static const char Tag_dataRate[];
     static const char Key_offsetDateTime[];
@@ -112,6 +114,7 @@ class AsciiSourceConfig {
     NamedParameter<bool, Key_limitFileBuffer, Tag_limitFileBuffer> _limitFileBuffer;
     NamedParameter<qint64, Key_limitFileBufferSize, Tag_limitFileBufferSize> _limitFileBufferSize;
     NamedParameter<int, Key_useThreads, Tag_useThreads> _useThreads;
+    NamedParameter<int, Key_fileRolling, Tag_fileRolling> _fileRolling;
     NamedParameter<double, Key_dataRate, Tag_dataRate> _dataRate;
     NamedParameter<bool, Key_offsetDateTime, Tag_offsetDateTime> _offsetDateTime;
     NamedParameter<bool, Key_offsetFileDate, Tag_offsetFileDate> _offsetFileDate;

--- a/src/libkst/updatemanager.h
+++ b/src/libkst/updatemanager.h
@@ -35,6 +35,7 @@ class KSTCORE_EXPORT UpdateManager : public QObject
 
     void setStore(ObjectStore *store) {_store = store;}
 
+    void askToReload() {emit dataSourceAskToReload();}
 
   public Q_SLOTS:
     void doUpdates(bool forceImmediate = false);
@@ -43,6 +44,7 @@ class KSTCORE_EXPORT UpdateManager : public QObject
 
   Q_SIGNALS:
     void objectsUpdated(qint64 serial);
+    void dataSourceAskToReload();
 
   private:
     UpdateManager();

--- a/src/libkstapp/mainwindow.cpp
+++ b/src/libkstapp/mainwindow.cpp
@@ -143,7 +143,8 @@ MainWindow::MainWindow() :
   connect(PlotItemManager::self(), SIGNAL(allPlotsTiedZoom()), this, SLOT(allPlotsTiedZoom()));
 
   readSettings();
-  connect(UpdateManager::self(), SIGNAL(objectsUpdated(qint64)), this, SLOT(updateViewItems(qint64)));
+  connect(UpdateManager::self(), SIGNAL(objectsUpdated(qint64)),  this, SLOT(updateViewItems(qint64)));
+  connect(UpdateManager::self(), SIGNAL(dataSourceAskToReload()), this, SLOT(reload()));
 
   QTimer::singleShot(0, this, SLOT(performHeavyStartupActions()));
 


### PR DESCRIPTION
When file size is less than previous, it means that have been overwritten. Added an option to force reload instead of clicking reload button.